### PR TITLE
Add a preflight test module and tests for it

### DIFF
--- a/playbooks/byo/preflight/library/check_yum_update.py
+++ b/playbooks/byo/preflight/library/check_yum_update.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python
+
+# tests whether a plain "yum update" will succeed
+
+import os
+import sys
+import yum
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict()
+    )
+    def bail(error):
+        module.fail_json(msg=error)
+
+    yb = yum.YumBase()
+    # determine if the existing yum configuration is valid
+    try:
+        yb.repos.populateSack(mdtype='metadata', cacheonly=1)
+    # for error of type:
+    #   1. can't reach the repo URL(s)
+    except yum.Errors.NoMoreMirrorsRepoError as e:
+        bail("Error getting data from at least one yum repository: %s" % e)
+    #   2. invalid repo definition
+    except yum.Errors.RepoError as e:
+        bail("Error with yum repository configuration: %s" % e)
+    #   3. other/unknown
+    #    * just report the problem verbatim
+    except:
+        bail("Unexpected error with yum repository: %s" % sys.exc_info()[1])
+
+    updates = yb.update()
+    # find out if there are any errors with the update
+    # for error of type:
+    #   1. dependency for update not found
+    #    * retrieve the dependency tree
+    #    * find the installed package(s) that required the missing dep
+    #    * determine if any of these packages matter to openshift
+    #    * build helpful error output
+    #   2. conflicts among packages in available content
+    #    * analyze dependency tree and build helpful error output
+    #   3. other/unknown
+    #    * just report the problem verbatim
+
+    #thing = type(updates[0])
+    #if updates:
+    #    for pkg in updates:
+    #        print "%s will be an update" % pkg
+    module.exit_json(changed=False)
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/preflight/check-yum-update/build.yml
+++ b/test/integration/preflight/check-yum-update/build.yml
@@ -1,0 +1,7 @@
+---
+- hosts: localhost
+  tasks:
+  - name: build and tag image
+    docker_image:
+      name: check-yum-update
+      path: docker

--- a/test/integration/preflight/check-yum-update/docker/Dockerfile
+++ b/test/integration/preflight/check-yum-update/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM centos:7
+RUN yum install -y rpm-build rpmdevtools createrepo && \
+    rpmdev-setuptree && \
+    mkdir -p /mnt/localrepo
+ADD root /
+RUN cd /root/rpmbuild/SOURCES && \
+    mkdir break-yum-update-1.0 && \
+    tar zfc foo.tgz break-yum-update-1.0 && \
+    rpmbuild -bb /root/break-yum-update.spec  && \
+    yum install -y /root/rpmbuild/RPMS/noarch/break-yum-update-1.0-1.noarch.rpm && \
+    rpmbuild -bb /root/break-yum-update-2.spec  && \
+    cp /root/rpmbuild/RPMS/noarch/break-yum-update-1.0-2.noarch.rpm /mnt/localrepo && \
+    createrepo /mnt/localrepo

--- a/test/integration/preflight/check-yum-update/docker/root/etc/yum.repos.d/local.repo
+++ b/test/integration/preflight/check-yum-update/docker/root/etc/yum.repos.d/local.repo
@@ -1,0 +1,5 @@
+[local]
+name=local
+baseurl=file:///mnt/localrepo
+enabled=1
+gpgcheck=0

--- a/test/integration/preflight/check-yum-update/docker/root/root/break-yum-update-2.spec
+++ b/test/integration/preflight/check-yum-update/docker/root/root/break-yum-update-2.spec
@@ -1,0 +1,33 @@
+Name:           break-yum-update
+Version:        1.0
+Release:        2
+Summary:        Package for breaking updates by requiring things that don't exist
+
+License:        NA
+
+Requires:	package-that-does-not-exist
+Source0:	http://example.com/foo.tgz
+BuildArch:	noarch
+
+%description
+Package for breaking updates by requiring things that don't exist
+
+
+%prep
+%setup -q
+
+
+%build
+
+
+%install
+rm -rf $RPM_BUILD_ROOT
+mkdir -p $RPM_BUILD_ROOT
+
+
+%files
+%doc
+
+
+
+%changelog

--- a/test/integration/preflight/check-yum-update/docker/root/root/break-yum-update.spec
+++ b/test/integration/preflight/check-yum-update/docker/root/root/break-yum-update.spec
@@ -1,0 +1,32 @@
+Name:           break-yum-update
+Version:        1.0
+Release:        1
+Summary:        Package for breaking updates by requiring things that don't exist
+
+License:        NA
+
+Source0:	http://example.com/foo.tgz
+BuildArch:	noarch
+
+%description
+Package for breaking updates by requiring things that don't exist
+
+
+%prep
+%setup -q
+
+
+%build
+
+
+%install
+rm -rf $RPM_BUILD_ROOT
+mkdir -p $RPM_BUILD_ROOT
+
+
+%files
+%doc
+
+
+
+%changelog

--- a/test/integration/preflight/check-yum-update/library
+++ b/test/integration/preflight/check-yum-update/library
@@ -1,0 +1,1 @@
+../../../../playbooks/byo/preflight/library

--- a/test/integration/preflight/check-yum-update/tasks/create-test-container.yml
+++ b/test/integration/preflight/check-yum-update/tasks/create-test-container.yml
@@ -1,0 +1,13 @@
+---
+- name: start new test container
+  docker_container:
+    name: "{{ container_name }}"
+    image: check-yum-update
+    recreate: true
+    command: "sleep 300"
+
+- name: add container to inventory
+  add_host:
+    name: "{{ container_name }}"
+    ansible_connection: docker
+  changed_when: false

--- a/test/integration/preflight/check-yum-update/tasks/delete-test-container.yml
+++ b/test/integration/preflight/check-yum-update/tasks/delete-test-container.yml
@@ -1,0 +1,6 @@
+---
+- name: delete test container
+  docker:
+    name: "{{ container_name }}"
+    image: check-yum-update
+    state: absent

--- a/test/integration/preflight/check-yum-update/test-upgrade-dependency-missing.yml
+++ b/test/integration/preflight/check-yum-update/test-upgrade-dependency-missing.yml
@@ -1,0 +1,13 @@
+---
+- hosts: localhost
+  vars:
+    container_name: check-yum-update-dep-missing
+  tasks:
+
+  - include: tasks/create-test-container.yml
+
+  - name: test should fail; cannot yum update due to dependencies
+    delegate_to: "{{ container_name }}"
+    action: check_yum_update
+
+  - include: tasks/delete-test-container.yml

--- a/test/integration/preflight/check-yum-update/test-yum-repo-broken.yml
+++ b/test/integration/preflight/check-yum-update/test-yum-repo-broken.yml
@@ -1,0 +1,19 @@
+---
+- hosts: localhost
+  vars:
+    container_name: check-yum-update-repo-broken
+  tasks:
+
+  - include: tasks/create-test-container.yml
+
+  - name: break the local yum repo
+    delegate_to: "{{ container_name }}"
+    replace: dest=/etc/yum.repos.d/local.repo backup=no
+             regexp='^baseurl'
+             replace='#baseurl'
+
+  - name: test should fail; reports broken repo
+    delegate_to: "{{ container_name }}"
+    action: check_yum_update
+
+  - include: tasks/delete-test-container.yml

--- a/test/integration/preflight/check-yum-update/test-yum-repo-disabled.yml
+++ b/test/integration/preflight/check-yum-update/test-yum-repo-disabled.yml
@@ -1,0 +1,19 @@
+---
+- hosts: localhost
+  vars:
+    container_name: check-yum-update-repo-disabled
+  tasks:
+
+  - include: tasks/create-test-container.yml
+
+  - name: disable the local yum repo
+    delegate_to: "{{ container_name }}"
+    replace: dest=/etc/yum.repos.d/local.repo backup=no
+             regexp='^enabled=1'
+             replace='enabled=0'
+
+  - name: test should succeed; nothing blocks a yum update
+    delegate_to: "{{ container_name }}"
+    action: check_yum_update
+
+  - include: tasks/delete-test-container.yml

--- a/test/integration/preflight/check-yum-update/test-yum-repo-unreachable.yml
+++ b/test/integration/preflight/check-yum-update/test-yum-repo-unreachable.yml
@@ -1,0 +1,17 @@
+---
+- hosts: localhost
+  vars:
+    container_name: check-yum-update-repo-unreachable
+  tasks:
+
+  - include: tasks/create-test-container.yml
+
+  - name: remove the local repo entirely
+    delegate_to: "{{ container_name }}"
+    file: path=/mnt/localrepo state=absent
+
+  - name: test should fail; repo cannot reach its url
+    delegate_to: "{{ container_name }}"
+    action: check_yum_update
+
+  - include: tasks/delete-test-container.yml

--- a/test/integration/preflight/check-yum-update_test.go
+++ b/test/integration/preflight/check-yum-update_test.go
@@ -1,0 +1,36 @@
+package preflight
+
+import (
+	"testing"
+)
+
+func TestUpgradeDependencyMissing(t *testing.T) {
+	PlaybookTest{
+		Path:     "check-yum-update/test-upgrade-dependency-missing.yml",
+		ExitCode: 1,
+		Output:   []string{"cannot yum update due to dependencies", "yum update will fail due to missing dependency"},
+	}.Run(t)
+}
+
+func TestYumRepoBroken(t *testing.T) {
+	PlaybookTest{
+		Path:     "check-yum-update/test-yum-repo-broken.yml",
+		ExitCode: 1,
+		Output:   []string{"reports broken repo", "Error with yum repository configuration"},
+	}.Run(t)
+}
+
+func TestYumRepoDisabled(t *testing.T) {
+	PlaybookTest{
+		Path:   "check-yum-update/test-yum-repo-disabled.yml",
+		Output: []string{"nothing blocks a yum update"},
+	}.Run(t)
+}
+
+func TestYumRepoUnreachable(t *testing.T) {
+	PlaybookTest{
+		Path:     "check-yum-update/test-yum-repo-unreachable.yml",
+		ExitCode: 1,
+		Output:   []string{"repo cannot reach its url", "Error getting data from at least one yum repository"},
+	}.Run(t)
+}


### PR DESCRIPTION
I present as a PR to get feedback on the layout in particular, as well as anything else about how I'm doing this. Could be a lot of newbie mistakes here.

I wasn't sure where to put the build step in for the go tests, probably some kind of Before() method that builds all the test images. For now you have to run that playbook yourself.

I ran into problems with the docker module that doesn't seem to be able to stop and delete a running container consistently. Not sure what to do with that. This makes the tests fail more than they're supposed to (only one test is supposed to fail because of missing module functionality).